### PR TITLE
 Add server subproject with cats-effect, fs2, and http4s

### DIFF
--- a/built.sbt
+++ b/built.sbt
@@ -24,7 +24,8 @@ lazy val root = (project in file(".")).
   ).aggregate(
     core.js,
     core.jvm,
-    core.native)
+    core.native,
+    server)
 
 lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .crossType(CrossType.Pure)
@@ -35,6 +36,14 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     startYear := Some(2025),
     libraryDependencies ++= Libraries.fallatol ++ Libraries.terminus 
   )
+
+lazy val server = (project in file("server"))
+  .settings(
+    commonSettings,
+    name := "scallamud-server",
+    startYear := Some(2025),
+    libraryDependencies ++= Libraries.cats ++ Libraries.fs2 ++ Libraries.http4s
+  ).dependsOn(core.jvm)
 
 addCommandAlias(
   "formatAll",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,14 +2,34 @@ import sbt.*
 
 object Dependencies {
   object V {
+    val cats = "2.10.0"
+    val catsEffect = "3.6.0-RC3"
     val fallatol = "0.3.1"
+    val fs2 = "3.9.3"
+    val http4s = "0.23.25"
     val terminus = "0.4.0"
   }
 
   object Libraries {
+    val cats: Seq[ModuleID] = Seq(
+      "org.typelevel" %% "cats-core" % V.cats,
+      "org.typelevel" %% "cats-effect" % V.catsEffect
+    )
+
     val fallatol: Seq[ModuleID] =
       Seq("org.kapunga" %% "fallatol-config" % V.fallatol)
-
+      
+    val fs2: Seq[ModuleID] = Seq(
+      "co.fs2" %% "fs2-core" % V.fs2,
+      "co.fs2" %% "fs2-io" % V.fs2
+    )
+    
+    val http4s: Seq[ModuleID] = Seq(
+      "org.http4s" %% "http4s-dsl" % V.http4s,
+      "org.http4s" %% "http4s-ember-server" % V.http4s,
+      "org.http4s" %% "http4s-ember-client" % V.http4s
+    )
+    
     val terminus: Seq[ModuleID] =
       Seq("org.creativescala" %% "terminus-core" % V.terminus)
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt.*
 object Dependencies {
   object V {
     val cats = "2.10.0"
-    val catsEffect = "3.6.0-RC3"
+    val catsEffect = "3.6.0-RC2"
     val fallatol = "0.3.1"
     val fs2 = "3.9.3"
     val http4s = "0.23.25"

--- a/server/src/main/scala/slm/server/ScallaMudServer.scala
+++ b/server/src/main/scala/slm/server/ScallaMudServer.scala
@@ -1,22 +1,24 @@
 package slm.server
 
-import cats.effect.{IO, IOApp}
+import cats.effect.{ IO, IOApp }
+import com.comcast.ip4s._
 import org.http4s.HttpRoutes
 import org.http4s.dsl.io._
-import org.http4s.implicits._
 import org.http4s.ember.server.EmberServerBuilder
-import com.comcast.ip4s._
+import org.http4s.implicits._
 
 /** Main server class for ScallaMUD.
   *
   * This class implements a simple HTTP server using http4s and cats-effect.
   */
 object ScallaMudServer extends IOApp.Simple:
-  
-  val routes = HttpRoutes.of[IO] {
-    case GET -> Root => Ok("Welcome to ScallaMUD!")
-    case GET -> Root / "status" => Ok("Server is running")
-  }.orNotFound
+
+  val routes = HttpRoutes
+    .of[IO] {
+      case GET -> Root            => Ok("Welcome to ScallaMUD!")
+      case GET -> Root / "status" => Ok("Server is running")
+    }
+    .orNotFound
 
   def run: IO[Unit] =
     for

--- a/server/src/main/scala/slm/server/ScallaMudServer.scala
+++ b/server/src/main/scala/slm/server/ScallaMudServer.scala
@@ -1,0 +1,34 @@
+package slm.server
+
+import cats.effect.{IO, IOApp}
+import org.http4s.HttpRoutes
+import org.http4s.dsl.io._
+import org.http4s.implicits._
+import org.http4s.ember.server.EmberServerBuilder
+import com.comcast.ip4s._
+
+/** Main server class for ScallaMUD.
+  *
+  * This class implements a simple HTTP server using http4s and cats-effect.
+  */
+object ScallaMudServer extends IOApp.Simple:
+  
+  val routes = HttpRoutes.of[IO] {
+    case GET -> Root => Ok("Welcome to ScallaMUD!")
+    case GET -> Root / "status" => Ok("Server is running")
+  }.orNotFound
+
+  def run: IO[Unit] =
+    for
+      _ <- IO.println("Starting ScallaMUD server...")
+      server <- EmberServerBuilder
+        .default[IO]
+        .withHost(ipv4"0.0.0.0")
+        .withPort(port"8080")
+        .withHttpApp(routes)
+        .build
+        .use(_ => IO.never)
+        .start
+      _ <- IO.println("Server started on port 8080")
+      _ <- server.join
+    yield ()


### PR DESCRIPTION
Playing around with Claude Code

 ## Summary
  * Created JVM-only server module that depends on core
  * Added typelevel libraries (cats, cats-effect 3.6.0-RC2, fs2, http4s)
  * Implemented simple IOApp-based HTTP server with basic endpoints

  ## Test plan
  * Run `sbt server/compile` to verify it builds
  * Run `sbt server/run` to start server and check http://localhost:8080/
